### PR TITLE
Implement responsive layout with media queries

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Responsive Layout</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="main-container">
+    <section class="section feed">
+      <h2>Feed</h2>
+      <p>Latest posts go here...</p>
+      <button class="primary">See more</button>
+    </section>
+    <section class="section groups">
+      <h2>Groups</h2>
+      <p>Browse groups you might like.</p>
+      <button class="primary">Browse</button>
+    </section>
+    <section class="section profile">
+      <h2>Profile</h2>
+      <p>Your personal information and settings.</p>
+      <button class="primary">Edit Profile</button>
+    </section>
+    <section class="section members">
+      <h2>Members</h2>
+      <p>See the community members.</p>
+      <button class="primary">View Members</button>
+    </section>
+  </div>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,88 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  font-size: 16px;
+}
+
+.main-container {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.section {
+  background: #f5f5f5;
+  padding: 1rem;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+}
+
+.section h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+}
+
+.section p {
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.primary {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: auto;
+}
+
+/* Breakpoint 600px */
+@media (min-width: 600px) {
+  body {
+    font-size: 17px;
+  }
+
+  .main-container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .primary {
+    width: auto;
+    align-self: flex-start;
+  }
+}
+
+/* Breakpoint 992px */
+@media (min-width: 992px) {
+  body {
+    font-size: 18px;
+  }
+
+  .main-container {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .section {
+    padding: 1.5rem;
+  }
+}
+
+/* Breakpoint 1200px */
+@media (min-width: 1200px) {
+  body {
+    font-size: 19px;
+  }
+
+  .main-container {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1.5rem;
+  }
+
+  .section {
+    padding: 2rem;
+  }
+
+  .primary {
+    align-self: flex-end;
+  }
+}


### PR DESCRIPTION
## Summary
- Add HTML structure for feed, groups, profile, and members inside a grid-based container.
- Introduce responsive CSS with media queries at 600px, 992px, and 1200px to adjust layout, typography, and spacing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0e56c838832ea8312f7b1430c595